### PR TITLE
docs(typescript): update main typescript snippet to be more correct

### DIFF
--- a/openllmetry/introduction.mdx
+++ b/openllmetry/introduction.mdx
@@ -39,7 +39,7 @@ def create_joke():
 import * as traceloop from "@traceloop/node-server-sdk";
 import OpenAI from "openai";
 
-Traceloop.init({ app_name="joke_generation_service" })
+traceloop.initialize({ appName: "joke_generation_service" })
 const openai = new OpenAI();
 
 class MyLLM {


### PR DESCRIPTION
The code snippet on this specific page is not accurate with how it should be consumed. In fact, it wouldn't even compile.

![Open-source_Observability_for_LLMs_with_OpenTelemetry](https://github.com/traceloop/docs/assets/1195435/559fda2a-b710-4d82-aaaa-0931f08fa8e5)

- "traceloop" capitalization. The imported SDK is lowercased, but the line changed uses a Capitalized version.
- `init` is actually `initialize` according to the `index.d.ts` file
- the config for `initialize` takes in an object with `appName` as a prop, not `app_name`

Please also notice that the snippet for TypeScript on this other page has the exact same issues: https://www.traceloop.com/openllmetry
