### PR TITLE
fix: otel-collector exporters setting

### DIFF
--- a/openllmetry/integrations/traceloop.mdx
+++ b/openllmetry/integrations/traceloop.mdx
@@ -43,7 +43,7 @@ processors:
   batch:
 exporters:
   otlphttp/traceloop:
-    endpoint: "api.traceloop.com" # US instance
+    endpoint: "https://api.traceloop.com" # US instance
     headers:
       "Authorization": "Bearer <YOUR_API_KEY>"
 service:


### PR DESCRIPTION
## About

I attempted to send traces to Traceloop using the OpenTelemetry Collector, but it was unsuccessful.
It seems to work with the previous configuration (where the schema is set), so I’m making adjustments based on that.

ref: https://github.com/traceloop/docs/commit/e8b94a67764112abf6629a743fa8e0d9568129b8