### PR TITLE
docs: update to reflect async/sync decorators merge #54

### DIFF
--- a/openllmetry/getting-started-python.mdx
+++ b/openllmetry/getting-started-python.mdx
@@ -48,7 +48,8 @@ We have a set of [decorators](/openllmetry/tracing/annotations) to make this eas
 Assume you have a function that renders a prompt and calls an LLM, simply add `@workflow`.
 
 <Warning>
-  If you're wrapping an async method, you'll need to use `@aworkflow` instead.
+  The `@aworkflow` decorator is deprecated and will be removed in a future version.
+  Use `@workflow` for both synchronous and asynchronous operations.
 </Warning>
 
 <Tip>
@@ -63,7 +64,8 @@ from traceloop.sdk.decorators import workflow
 def suggest_answers(question: str):
   ...
 
-@aworkflow(name="summarize")
+# Works seamlessly with async functions too
+@workflow(name="summarize")
 async def summarize(long_text: str):
   ...
 ```

--- a/openllmetry/tracing/annotations.mdx
+++ b/openllmetry/tracing/annotations.mdx
@@ -294,8 +294,10 @@ async function history_jokes_tool() {
 
 In Typescript, you can use the same syntax for async methods.
 
-In Python, you'll need to switch to an equivalent async decorator.
-So, if you're decorating an `async` method, use `@aworkflow`, `@atask` and so forth.
+In python, the decorators work seamlessly with both synchronous and asynchronous functions.
+Use `@workflow`, `@task`, `@agent`, and so forth for both sync and async methods.
+
+The async-specific decorators (`@aworkflow`, `@atask`, etc.) are deprecated and will be removed in a future version.
 
 See also a [separate section on using threads in Python with OpenLLMetry](/openllmetry/tracing/python-threads).
 


### PR DESCRIPTION
Update the code sample to support the unified async/sync merge detailed in issue https://github.com/traceloop/openllmetry/issues/2434.

PR with code changed at:  https://github.com/traceloop/openllmetry/pull/2442

Fixed #54
