### PR TITLE
Add BMC as a company that supports Openllmetry integration

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -110,6 +110,7 @@
         "openllmetry/integrations/axiom",
         "openllmetry/integrations/azure",
         "openllmetry/integrations/braintrust",
+        "openllmetry/integrations/bmc",
         "openllmetry/integrations/dash0",
         "openllmetry/integrations/datadog",
         "openllmetry/integrations/dynatrace",

--- a/openllmetry/integrations/bmc.mdx
+++ b/openllmetry/integrations/bmc.mdx
@@ -1,0 +1,25 @@
+---
+title: "LLM Observability with BMC and OpenLLMetry"
+sidebarTitle: "BMC Helix"
+---
+
+BMC Helix provides the capability to export observability data directly using the OpenTelemetry Collector. This requires deploying an OpenTelemetry Collector in your cluster.
+
+See also [BMC Helix documentation](https://docs.bmc.com/xwiki/bin/view/IT-Operations-Management/Operations-Management/BMC-Helix-AIOps/aiops244/Administering/Enabling-BMC-Helix-applications-to-collect-service-traces-from-OpenTelemetry/).
+
+Exporting Data to an OpenTelemetry Collector
+
+
+```yaml
+otlp:
+  receiver:
+    protocols:
+      http:
+        enabled: true
+```
+
+Then, set this env var, and you're done!
+
+```bash
+TRACELOOP_BASE_URL=http://<tenantURL>
+```

--- a/openllmetry/integrations/introduction.mdx
+++ b/openllmetry/integrations/introduction.mdx
@@ -16,6 +16,7 @@ in any observability platform that supports OpenTelemetry.
     href="/openllmetry/integrations/azure"
   ></Card>
   <Card title="Braintrust" href="/openllmetry/integrations/braintrust"></Card>
+  <Card title="BMC" href="/openllmetry/integrations/bmc"></Card>
   <Card title="Dash0" href="/openllmetry/integrations/dash0"></Card>
   <Card title="Datadog" href="/openllmetry/integrations/datadog"></Card>
   <Card title="Dynatrace" href="/openllmetry/integrations/dynatrace"></Card>


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add documentation for BMC Helix integration with Openllmetry using OpenTelemetry Collector.
> 
>   - **Documentation**:
>     - Adds `bmc.mdx` to document integration of BMC Helix with Openllmetry.
>     - Provides configuration for exporting observability data using OpenTelemetry Collector.
>     - Includes reference to BMC Helix documentation for further details.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for cca8aab71731f30e3169efe82402fd285058b0fd. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->