### PR TITLE
Routing to Dynatrace docs link

### DIFF
--- a/openllmetry/integrations/dynatrace.mdx
+++ b/openllmetry/integrations/dynatrace.mdx
@@ -11,18 +11,18 @@ Analyze all collected LLM traces within Dynatrace by using the native OpenTeleme
 
 Go to your Dynatrace environment and create a new access token under **Manage Access Tokens**.  
 The access token needs the following permission scopes that allow the ingest of OpenTelemetry spans, metrics and logs
-(openTelemetryTrace.ingest, metrics.ingest, logs.ingest).
+(openTelemetryTrace.ingest, metrics.ingest, logs.ingest, events.ingest, metrics.read, settings.write).
 
-Set `TRACELOOP_BASE_URL` environment variable to the URL of your Dynatrace OpenTelemetry ingest endpoint
+Initialize OpenLLMetry with the token to collect all the relevant KPIs.
 
-```bash
-TRACELOOP_BASE_URL=https://<YOUR_ENV>.live.dynatrace.com\api\v2\otlp
-```
+Add in the OTLP API endpoint of your Dynatrace environment.
 
-Set the `TRACELOOP_HEADERS` environment variable to include your previously created access token
+from traceloop.sdk import Traceloop
+headers = { "Authorization": "Api-Token <YOUR_DT_API_TOKEN>" }
+Traceloop.init(
+    app_name="<your-service>",
+    api_endpoint="https://<YOUR_ENV>.live.dynatrace.com/api/v2/otlp",
+    headers=headers
+)
 
-```bash
-TRACELOOP_HEADERS=Authorization=Api-Token%20<YOUR_ACCESS_TOKEN>
-```
-
-Done! All the exported spans along with their span attributes will show up within the Dynatrace trace view.
+Done! All the exported spans along with their span attributes will show up within the Dynatrace trace view. For more information, check out the [docs link](https://docs.dynatrace.com/docs/shortlink/ai-ml-get-started).


### PR DESCRIPTION
1. Edited the scopes required for the access token
2. Since Environment variables aren't recommended by Dynatrace as much as sending in the API URL in the init section, suggesting routing directly to the Dynatrace docs for reference too.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates Dynatrace integration docs to modify access token scopes, suggest direct API URL initialization, and add a documentation link.
> 
>   - **Documentation**:
>     - Updates required access token scopes in `dynatrace.mdx` to include `events.ingest`, `metrics.read`, and `settings.write`.
>     - Recommends initializing OpenLLMetry with the API URL directly in `dynatrace.mdx`, replacing environment variable usage.
>     - Adds a link to Dynatrace documentation for further reference in `dynatrace.mdx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 055e587c0b751b08358c5491559c9a45b293e5f3. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->