### PR TITLE
fix(costs): require fields in costs doc

### DIFF
--- a/api-reference/costs/property_costs.mdx
+++ b/api-reference/costs/property_costs.mdx
@@ -11,16 +11,16 @@ Query your LLM costs broken down by a specific association property. This helps 
   The name of the association property to group costs by (e.g., "user_id", "session_id").
 </ParamField>
 
-<ParamField query="env" type="string">
-  List of environments to include in the calculation. Separated by comma.
-</ParamField>
-
-<ParamField query="start_time" type="string">
+<ParamField query="start_time" type="string" required>
   The start time in ISO 8601 format (e.g., "2025-04-15T00:00:00Z").
 </ParamField>
 
-<ParamField query="end_time" type="string">
+<ParamField query="end_time" type="string" required>
   The end time in ISO 8601 format (e.g., "2025-04-28T23:00:00Z").
+</ParamField>
+
+<ParamField query="env" type="string">
+  List of environments to include in the calculation. Separated by comma.
 </ParamField>
 
 ## Response


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Make `start_time` and `end_time` required in `property_costs.mdx` and reorder `env` parameter.
> 
>   - **Request Parameters**:
>     - `start_time` and `end_time` parameters in `property_costs.mdx` are now required.
>     - Reordered `env` parameter to follow `end_time` for better logical grouping.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 42e3a2f7a0ffac7d06894b777b7c828750342e9d. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->