### PR TITLE
Revert "Routing to Dynatrace docs link"

### DIFF
--- a/openllmetry/integrations/dynatrace.mdx
+++ b/openllmetry/integrations/dynatrace.mdx
@@ -11,18 +11,18 @@ Analyze all collected LLM traces within Dynatrace by using the native OpenTeleme
 
 Go to your Dynatrace environment and create a new access token under **Manage Access Tokens**.  
 The access token needs the following permission scopes that allow the ingest of OpenTelemetry spans, metrics and logs
-(openTelemetryTrace.ingest, metrics.ingest, logs.ingest, events.ingest, metrics.read, settings.write).
+(openTelemetryTrace.ingest, metrics.ingest, logs.ingest).
 
-Initialize OpenLLMetry with the token to collect all the relevant KPIs.
+Set `TRACELOOP_BASE_URL` environment variable to the URL of your Dynatrace OpenTelemetry ingest endpoint
 
-Add in the OTLP API endpoint of your Dynatrace environment.
+```bash
+TRACELOOP_BASE_URL=https://<YOUR_ENV>.live.dynatrace.com\api\v2\otlp
+```
 
-from traceloop.sdk import Traceloop
-headers = { "Authorization": "Api-Token <YOUR_DT_API_TOKEN>" }
-Traceloop.init(
-    app_name="<your-service>",
-    api_endpoint="https://<YOUR_ENV>.live.dynatrace.com/api/v2/otlp",
-    headers=headers
-)
+Set the `TRACELOOP_HEADERS` environment variable to include your previously created access token
 
-Done! All the exported spans along with their span attributes will show up within the Dynatrace trace view. For more information, check out the [docs link](https://docs.dynatrace.com/docs/shortlink/ai-ml-get-started).
+```bash
+TRACELOOP_HEADERS=Authorization=Api-Token%20<YOUR_ACCESS_TOKEN>
+```
+
+Done! All the exported spans along with their span attributes will show up within the Dynatrace trace view.


### PR DESCRIPTION
Reverts traceloop/docs#72

fyi @shrilekha - this isn't working. Please submit a new PR and make sure it works for you locally.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts changes in `dynatrace.mdx` to previous documentation format, removing environment variable setup and access token scope modifications.
> 
>   - **Revert Changes**:
>     - Reverts changes in `dynatrace.mdx` related to setting `TRACELOOP_BASE_URL` and `TRACELOOP_HEADERS` environment variables.
>     - Removes instructions for modifying access token permission scopes to include `events.ingest`, `metrics.read`, and `settings.write`.
>   - **Documentation**:
>     - Reverts to previous documentation format for Dynatrace integration setup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for ae406e04fd16e9091c0663fbe2df8eee726bf9d1. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->