### PR TITLE
fix: updated onprem installation instructions

### DIFF
--- a/self-host/full-deployment.mdx
+++ b/self-host/full-deployment.mdx
@@ -34,79 +34,152 @@ The Full Platform deployment provides complete control over the entire Traceloop
 
 ## Deployment Process
 
-### 1. Set Up Required Operators
 
-```bash
-# Create namespace for Doppler operator
-kubectl create namespace doppler-operator-system
-
-# Add Doppler Helm repository
-helm repo add doppler https://helm.doppler.com
-
-# Install Doppler Kubernetes operator
-helm install --generate-name doppler/doppler-kubernetes-operator
-
-# Create Doppler service token secret
-kubectl create secret generic doppler-token-secret \
-  --namespace doppler-operator-system \
-  --from-literal=serviceToken=<doppler-token-provided-by-traceloop>
-```
-
-### 2. Configure Namespace and Registry Access
+### 1. Configure Namespace
 
 ```bash
 # Create Traceloop namespace
 kubectl create namespace traceloop
+```
 
-# Create Docker Hub pull secret
+### 2. Create required secrets under traceloop namespace
+
+#### Docker Hub image pull secret
+```bash
 kubectl create secret docker-registry regcred \
   --namespace traceloop \
   --docker-server=docker.io \
   --docker-username=<dockerhub-username-provided-by-traceloop> \
   --docker-password=<dockerhub-password-provided-by-traceloop>
 ```
+#### Postges Sccret (if not already present)
+```bash
+kubectl create secret generic traceloop-postgres-secret \
+  --namespace traceloop \
+  --from-literal=POSTGRES_DATABASE_USERNAME=<postgres-username> \
+  --from-literal=POSTGRES_DATABASE_PASSWORD=<postgres-password>
+```
 
-### 3. Install Traceloop Platform
+#### ClickHouse Secret (if not already present)
+```bash
+kubectl create secret generic traceloop-clickhouse-secret \
+  --namespace traceloop \
+  --from-literal=CLICKHOUSE_USERNAME=<clickhouse-username> \
+  --from-literal=CLICKHOUSE_PASSWORD=<clickhouse-password>
+```
+
+#### Kafka Secret (if not already present)
+```bash
+kubectl create secret generic traceloop-kafka-secret \
+  --namespace traceloop \
+  --from-literal=KAFKA_API_KEY=<kafka-api-key> \
+  --from-literal=KAFKA_API_SECRET=<kafka-api-secret>
+```
+### 3. Pull Traceloop helm chart on your desired location
 
 ```bash
 # Add Traceloop Helm repository
-helm repo add traceloop https://helm.traceloop.com
-helm repo update
-
-# Install Traceloop
-helm install traceloop \
-  --namespace traceloop \
-  --create-namespace \
-  --values values.yaml \
-  --dependency-update
+helm pull oci://registry-1.docker.io/traceloop/helm
 ```
 
-Example `values.yaml`:
+### 4. Unzip and run subcharts extractions script
+
+```bash
+unzip traceloop-helm-chart.zip
+chmod +x extract-subcharts.sh
+./extract-subcharts.sh
+```
+
+### 5. Update `values-customer.yaml` with your domain & auth configuration:
 
 ```yaml
-infrastructure:
-  clickhouse:
-    host: "your-clickhouse-host"
-    user: "your-clickhouse-user"
-    password: "your-clickhouse-password"
+kong-gateway:
+  service:
+    type: NodePort # Or ClusterIP
+    proxy:
+      # port: 8000
+      # targetPort: 8000
+      nodePort: 30080
+    status:
+      # port: 8100
+      # targetPort: 8100
+      nodePort: 30081
+  kong:
+    domain: "user-provided"
+    appSubdomain: "app" # Can be overridden by customer
+    apiSubdomain: "api" # Can be overridden by customer
+    realtimeSubdomain: "realtime" # Can be overridden by customer
 
-  kafka:
-    brokers: "your-kafka-broker:9092"
+helm-api-service:
+  app:
+    imagesSupport:
+      enabled: false # Can be overridden by customer
+      s3ImagesBucket: "" # Can be overridden by customer
+      eksRegion: "" # Can be overridden by customer
 
-  postgresql:
-    host: "your-postgres-host"
-    user: "your-postgres-user"
-    password: "your-postgres-password"
+customerConfig:
+  propelauth:
+    authURL: "traceloop-provided"
+  launchDarkly:
+    clientId: "" # OPTIONAL traceloop-provided
 
-security:
-  auth:
-    secretKey: "your-secure-random-string"
+customerSecret:
+  openai:
+    key: "user-provided"
+  launchDarkly:
+    apiKey: "" # OPTIONAL traceloop-provided
+  propelauth:
+    verifierKey: "traceloop-provided"
+    apiKey: "traceloop-provided"
+```
 
-platform:
-  airgapped: false
-  ingress:
-    enabled: true
-    host: "traceloop.your-domain.com"
+### 6. Update `values-external-postgres.yaml`, `values-external-clickhouse.yaml`, `values-external-kafka.yaml` with relevant addresses
+`values-external-postgres.yaml`
+```yaml
+postgresql:
+  enabled: false
+  host: ""  # Example: "my-postgres-server.example.com"
+  port: ""  # Example: "5432"
+  database: ""  # Example: "traceloop"
+```
+
+`values-external-clickhouse.yaml`
+```yaml
+clickhouse:
+  enabled: false
+  host: ""  # Example: "my-clickhouse-server.example.com"
+  port: ""  # Example: "9440"
+  httpPort: ""  # Example: "8443"
+  database: ""  # Example: "default"
+  sslMode: ""  # Example: "strict" or "none"
+  sslEnabled: ""  # Example: "true" or "false"
+```
+
+`values-external-kafka.yaml`
+```yaml
+kafka:
+  enabled: false
+  bootstrapServer: ""  # Example: "my-kafka-broker.example.com:9092"
+  securityProtocol: ""  # Example: "SASL_SSL" or "PLAINTEXT"
+  saslMechanisms: ""  # Example: "PLAIN" or "SCRAM-SHA-256"
+  apiKey: ""  # Your Kafka API key if required
+  apiSecret: ""  # Your Kafka API secret if required
+```
+
+### 7. Install Traceloop
+```bash
+## 5. Helm install
+helm upgrade --install traceloop . \
+  -n traceloop \
+  --values values.yaml \
+  --values values-customer.yaml \
+  --values values-internal-kafka.yaml \
+  --values values-internal-clickhouse.yaml \
+  --values values-internal-postgres.yaml \
+  --values values-temporal.yaml \
+  --values values-centrifugo.yaml \
+  --create-namespace \
+  --dependency-update
 ```
 
 <Warning>

--- a/self-host/full-deployment.mdx
+++ b/self-host/full-deployment.mdx
@@ -35,18 +35,18 @@ The Full Platform deployment provides complete control over the entire Traceloop
 ## Deployment Process
 
 
-### 1. Configure Namespace
+### 1. Create Traceloop namespace
 
 ```bash
-# Create Traceloop namespace
 kubectl create namespace traceloop
 ```
 
 ### 2. Create required secrets under traceloop namespace
 
-#### Docker Hub image pull secret
+#### Docker Hub images pull secret.
+Credentials will be provided by Traceloop via secure channel
+
 ```bash
-# docker-registry credentials will be provided by Traceloop via secure channel
 kubectl create secret docker-registry regcred \
   --namespace traceloop \
   --docker-server=docker.io \
@@ -80,13 +80,12 @@ kubectl create secret generic traceloop-kafka-secret \
 
 ```bash
 # Add Traceloop Helm repository
-helm pull oci://registry-1.docker.io/traceloop/helm
+helm pull oci://registry-1.docker.io/traceloop/helm --untar
 ```
 
-### 4. Unzip and run subcharts extractions script
+### 4. Run subcharts and dependency extractions script
 
 ```bash
-unzip traceloop-helm-chart.zip
 chmod +x extract-subcharts.sh
 ./extract-subcharts.sh
 ```
@@ -135,8 +134,8 @@ customerSecret:
 
 ### 6. Update the following files with relevant addresses
 
+#### values-external-postgres.yaml
 ```yaml
-# values-external-postgres.yaml
 postgresql:
   enabled: false
   host: ""  # Example: "my-postgres-server.example.com"
@@ -144,9 +143,8 @@ postgresql:
   database: ""  # Example: "traceloop"
 ```
 
-
+#### values-external-clickhouse.yaml
 ```yaml
-# values-external-clickhouse.yaml
 clickhouse:
   enabled: false
   host: ""  # Example: "my-clickhouse-server.example.com"
@@ -157,18 +155,18 @@ clickhouse:
   sslEnabled: ""  # Example: "true" or "false"
 ```
 
+#### values-external-kafka.yaml
 ```yaml
-# values-external-kafka.yaml
 kafka:
   enabled: false
-  bootstrapServer: ""  # Example: "my-kafka-broker.example.com:9092"
+  bootstrapServer: ""  # Example: "kafka-broker.example.com:9092"
   securityProtocol: ""  # Example: "SASL_SSL" or "PLAINTEXT"
   saslMechanisms: ""  # Example: "PLAIN" or "SCRAM-SHA-256"
   apiKey: ""  # Your Kafka API key if required
   apiSecret: ""  # Your Kafka API secret if required
 ```
 
-### 7. Install Traceloop
+### 7. Install Traceloop Helm chart
 ```bash
 helm upgrade --install traceloop . \
   -n traceloop \
@@ -182,11 +180,6 @@ helm upgrade --install traceloop . \
   --create-namespace \
   --dependency-update
 ```
-
-<Warning>
-  For air-gapped environments: 1. Download all required container images 2. Set
-  `platform.airgapped: true` 3. Configure private registry settings
-</Warning>
 
 ## Verification
 

--- a/self-host/full-deployment.mdx
+++ b/self-host/full-deployment.mdx
@@ -46,6 +46,7 @@ kubectl create namespace traceloop
 
 #### Docker Hub image pull secret
 ```bash
+# docker-registry credentials will be provided by Traceloop via secure channel
 kubectl create secret docker-registry regcred \
   --namespace traceloop \
   --docker-server=docker.io \
@@ -75,7 +76,7 @@ kubectl create secret generic traceloop-kafka-secret \
   --from-literal=KAFKA_API_KEY=<kafka-api-key> \
   --from-literal=KAFKA_API_SECRET=<kafka-api-secret>
 ```
-### 3. Pull Traceloop helm chart on your desired location
+### 3. Download the Traceloop Helm chart to your local environmen
 
 ```bash
 # Add Traceloop Helm repository
@@ -91,7 +92,6 @@ chmod +x extract-subcharts.sh
 ```
 
 ### 5. Update `values-customer.yaml` with your domain & auth configuration:
-
 ```yaml
 kong-gateway:
   service:
@@ -133,9 +133,10 @@ customerSecret:
     apiKey: "traceloop-provided"
 ```
 
-### 6. Update `values-external-postgres.yaml`, `values-external-clickhouse.yaml`, `values-external-kafka.yaml` with relevant addresses
-`values-external-postgres.yaml`
+### 6. Update the following files with relevant addresses
+
 ```yaml
+# values-external-postgres.yaml
 postgresql:
   enabled: false
   host: ""  # Example: "my-postgres-server.example.com"
@@ -143,8 +144,9 @@ postgresql:
   database: ""  # Example: "traceloop"
 ```
 
-`values-external-clickhouse.yaml`
+
 ```yaml
+# values-external-clickhouse.yaml
 clickhouse:
   enabled: false
   host: ""  # Example: "my-clickhouse-server.example.com"
@@ -155,8 +157,8 @@ clickhouse:
   sslEnabled: ""  # Example: "true" or "false"
 ```
 
-`values-external-kafka.yaml`
 ```yaml
+# values-external-kafka.yaml
 kafka:
   enabled: false
   bootstrapServer: ""  # Example: "my-kafka-broker.example.com:9092"
@@ -168,14 +170,13 @@ kafka:
 
 ### 7. Install Traceloop
 ```bash
-## 5. Helm install
 helm upgrade --install traceloop . \
   -n traceloop \
   --values values.yaml \
   --values values-customer.yaml \
-  --values values-internal-kafka.yaml \
-  --values values-internal-clickhouse.yaml \
-  --values values-internal-postgres.yaml \
+  --values values-external-kafka.yaml \
+  --values values-external-clickhouse.yaml \
+  --values values-external-postgres.yaml \
   --values values-temporal.yaml \
   --values values-centrifugo.yaml \
   --create-namespace \

--- a/self-host/full-deployment.mdx
+++ b/self-host/full-deployment.mdx
@@ -76,7 +76,7 @@ kubectl create secret generic traceloop-kafka-secret \
   --from-literal=KAFKA_API_KEY=<kafka-api-key> \
   --from-literal=KAFKA_API_SECRET=<kafka-api-secret>
 ```
-### 3. Download the Traceloop Helm chart to your local environmen
+### 3. Download the Traceloop Helm chart to your local environment
 
 ```bash
 # Add Traceloop Helm repository

--- a/self-host/full-deployment.mdx
+++ b/self-host/full-deployment.mdx
@@ -52,7 +52,7 @@ kubectl create secret docker-registry regcred \
   --docker-username=<dockerhub-username-provided-by-traceloop> \
   --docker-password=<dockerhub-password-provided-by-traceloop>
 ```
-#### Postges Sccret (if not already present)
+#### Postgres Secret (if not already present)
 ```bash
 kubectl create secret generic traceloop-postgres-secret \
   --namespace traceloop \


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Updates Traceloop on-prem installation guide, adding namespace, secrets setup, and detailed Helm chart configuration steps.
> 
>   - **Namespace and Secrets**:
>     - Removes Doppler operator setup.
>     - Adds instructions to create `traceloop` namespace.
>     - Adds steps to create Docker Hub, Postgres, ClickHouse, and Kafka secrets.
>   - **Helm Chart Setup**:
>     - Updates instructions to download and extract Traceloop Helm chart.
>     - Adds steps to update `values-customer.yaml` and other configuration files with domain and auth settings.
>     - Provides command to install Traceloop Helm chart with multiple `values` files.
>   - **Configuration Files**:
>     - Adds `values-external-postgres.yaml`, `values-external-clickhouse.yaml`, and `values-external-kafka.yaml` for external service configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 465d71264b48feff6f43dbaaf367a58a1725a689. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->