### PR TITLE
doc: update link to otel semcov genai project

### DIFF
--- a/openllmetry/contributing/semantic-conventions.mdx
+++ b/openllmetry/contributing/semantic-conventions.mdx
@@ -4,7 +4,7 @@ title: "GenAI Semantic Conventions"
 
 With OpenLLMetry, we aim at defining an extension of the standard
 [OpenTelemetry Semantic Conventions](https://github.com/open-telemetry/semantic-conventions) for gen AI applications.
-We are also [leading OpenTelemetry's LLM semantic convention WG](https://github.com/open-telemetry/community/blob/main/projects/llm-semconv.md)
+We are also [leading OpenTelemetry's LLM semantic convention WG](https://github.com/open-telemetry/community/blob/main/projects/gen-ai.md)
 to standardize these conventions.
 
 It defines additional attributes for spans to so we can log prompts, completions, token usage, etc.


### PR DESCRIPTION
## What
Updated the link to Opentelemetry's LLM semantic convention WG.

## Why
The link seems to be outdated.