### PR TITLE
fix(self-hosting): token hmac secret name

### DIFF
--- a/self-host/full-deployment.mdx
+++ b/self-host/full-deployment.mdx
@@ -179,7 +179,7 @@ customerSecret:
     apiKey: "traceloop-provided"
   centrifugo:
     apiKey: "user-provided"
-    tokenHmacSecret: "user-provided"
+    tokenHmacSecretKey: "user-provided"
   encryptionSecret:
     apiKey: "user-provided"
 ```


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Rename `tokenHmacSecret` to `tokenHmacSecretKey` in `self-host/full-deployment.mdx` for `centrifugo` configuration.
> 
>   - **Configuration**:
>     - Rename `tokenHmacSecret` to `tokenHmacSecretKey` in `self-host/full-deployment.mdx` under `centrifugo` configuration.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 41f8c7a9f0a0e822c70070dd9ef5601869d47a66. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated deployment guide to reflect the renaming of a configuration key from `tokenHmacSecret` to `tokenHmacSecretKey` for Centrifugo service authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->