### PR TITLE
fix: typo in env var name

### DIFF
--- a/openllmetry/configuration.mdx
+++ b/openllmetry/configuration.mdx
@@ -53,7 +53,7 @@ For configuring this to different observability platform, check out our [integra
 <Note>
   The OpenTelemetry standard defines that the actual endpoint should always end
   with `/v1/traces`. Thus, if you specify a base URL, we always append
-  `/v1/traces` to it. This is similar to how `OTLP_EXPORTER_OTLP_ENDPOINT` works
+  `/v1/traces` to it. This is similar to how `OTEL_EXPORTER_OTLP_ENDPOINT` works
   in all OpenTelemetry SDKs.
 </Note>
 


### PR DESCRIPTION
- ref: https://opentelemetry.io/docs/languages/sdk-configuration/otlp-exporter/#otel_exporter_otlp_endpoint