### PR TITLE
docs: fix typo in semantic-conventions.mdx

### DIFF
--- a/openllmetry/contributing/semantic-conventions.mdx
+++ b/openllmetry/contributing/semantic-conventions.mdx
@@ -63,8 +63,8 @@ This is a work in progress, and we welcome your feedback and contributions!
 - `pinecone.query.id`
 - `pinecone.query.namespace`
 - `pinecone.query.top_k`
-- `pinecone.usage.read_units` - The number of read units used (as reported by Piinecone)
-- `pinecone.usage.write_units` - The number of write units used (as reported by Piinecone)
+- `pinecone.usage.read_units` - The number of read units used (as reported by Pinecone)
+- `pinecone.usage.write_units` - The number of write units used (as reported by Pinecone)
 
 ### LLM Frameworks
 


### PR DESCRIPTION
- replace piinecone with pinecone in
- [reference](https://www.traceloop.com/docs/openllmetry/contributing/semantic-conventions#pinecone-specific)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix typo in `semantic-conventions.mdx`, changing 'Piinecone' to 'Pinecone'.
> 
>   - Fix typo in `semantic-conventions.mdx`, changing 'Piinecone' to 'Pinecone' in two instances.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 1ec322a049777e065662551ccbcffda50f058e59. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed a typographical error in the Pinecone-specific semantic conventions section by correcting the spelling of "Pinecone."

<!-- end of auto-generated comment: release notes by coderabbit.ai -->