### PR TITLE
docs: add reasoning attributes

### DIFF
--- a/openllmetry/contributing/semantic-conventions.mdx
+++ b/openllmetry/contributing/semantic-conventions.mdx
@@ -34,6 +34,10 @@ This is a work in progress, and we welcome your feedback and contributions!
 - `gen_ai.usage.prompt_tokens` - The number of tokens used for the prompt in the request
 - `gen_ai.usage.completion_tokens` - The number of tokens used for the completion response
 - `gen_ai.usage.total_tokens` - The total number of tokens used
+- `gen_ai.usage.reasoning_tokens` (OpenAI) - The total number of reasoning tokens used as a part of `completion_tokens`
+- `gen_ai.request.reasoning_effort` (OpenAI) - Reasoning effort mentioned in the request (e.g. `minimal`, `low`, `medium`, or `high`)
+- `gen_ai.request.reasoning_summary` (OpenAI) - Level of reasoning summary mentioned in the request (e.g. `auto`, `concise`, or `detailed`)
+- `gen_ai.response.reasoning_effort` (OpenAI) - Actual reasoning effort used
 
 - `llm.request.type` - The type of request (e.g. `completion`, `chat`, etc.)
 - `llm.usage.total_tokens` - The total number of tokens used


### PR DESCRIPTION
This is a step to solve issue https://github.com/traceloop/openllmetry/issues/3257

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Added new reasoning-related attributes to OpenLLMetry semantic conventions for OpenAI models.
> 
>   - **Attributes Added**:
>     - `gen_ai.usage.reasoning_tokens`: Total reasoning tokens used in `completion_tokens`.
>     - `gen_ai.request.reasoning_effort`: Reasoning effort in request (`minimal`, `low`, `medium`, `high`).
>     - `gen_ai.request.reasoning_summary`: Reasoning summary level in request (`auto`, `concise`, `detailed`).
>     - `gen_ai.response.reasoning_effort`: Actual reasoning effort used.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 32766b72919e2c318ce78ef9313dad327eeb2261. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->