### PR TITLE
chore(docs): fix costs route typo

### DIFF
--- a/api-reference/costs/property_costs.mdx
+++ b/api-reference/costs/property_costs.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Get costs by property"
-api: "GET https://api.traceloop.com/api/v2/costs/by-association-property"
+api: "GET https://api.traceloop.com/v2/costs/by-association-property"
 ---
 
 Query your LLM costs broken down by a specific association property. This helps you understand how costs are distributed across different values of a property (e.g., by user_id, session_id, or any other association property you track).


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Fixes URL in `property_costs.mdx` for the costs route to correct endpoint.
> 
>   - **API Reference**:
>     - Fixes URL in `property_costs.mdx` from `https://api.traceloop.com/api/v2/costs/by-association-property` to `https://api.traceloop.com/v2/costs/by-association-property`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 884657daca774df2c27b5e30ed8414ba782f8445. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the API reference for the Costs by Association Property endpoint to use the new URL: GET https://api.traceloop.com/v2/costs/by-association-property (previously https://api.traceloop.com/api/v2/costs/by-association-property).
  * No changes to parameters, response schema, examples, or error handling.
  * Action: Update any integrations or bookmarks to the new endpoint URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->