### PR TITLE
chore(docs): add costs page

### DIFF
--- a/api-reference/costs/property_costs.mdx
+++ b/api-reference/costs/property_costs.mdx
@@ -1,0 +1,84 @@
+---
+title: "Get costs by property"
+api: "GET https://api.traceloop.com/v2/costs/by-association-property"
+---
+
+Query your LLM costs broken down by a specific association property. This helps you understand how costs are distributed across different values of a property (e.g., by user_id, session_id, or any other association property you track).
+
+## Request Parameters
+
+<ParamField query="property_name" type="string" required>
+  The name of the association property to group costs by (e.g., "user_id", "session_id").
+</ParamField>
+
+<ParamField query="start_time" type="string" required>
+  The start time in ISO 8601 format (e.g., "2025-04-15T00:00:00Z").
+</ParamField>
+
+<ParamField query="end_time" type="string" required>
+  The end time in ISO 8601 format (e.g., "2025-04-28T23:00:00Z").
+</ParamField>
+
+<ParamField query="env" type="string">
+  List of environments to include in the calculation. Separated by comma.
+</ParamField>
+
+<ParamField query="selected_token_types" type="string">
+  <span style={{backgroundColor: '#10b981', color: 'white', padding: '2px 6px', borderRadius: '4px', fontSize: '12px', fontWeight: 'bold'}}>NEW</span> Filter costs by specific token types. Separate multiple types with commas.
+  
+  **Supported token types:**
+  - `input_tokens` or `prompt_tokens` (automatically normalized to `prompt_tokens`)
+  - `output_tokens` or `completion_tokens` (automatically normalized to `completion_tokens`)
+  - `cache_read_input_tokens`
+  - `cache_creation_input_tokens`
+  - Other token types as they appear in your data
+  
+  **Note:** `total_tokens` cannot be used as a filter.
+  
+  **Examples:**
+  - `selected_token_types=input_tokens,output_tokens`
+  - `selected_token_types=prompt_tokens,cache_read_input_tokens`
+  - `selected_token_types=completion_tokens`
+  
+  When this parameter is omitted, costs for all token types are included.
+</ParamField>
+
+## Response
+
+<ResponseField name="property_name" type="string">
+  The name of the property that was queried.
+</ResponseField>
+
+<ResponseField name="values" type="PropertyValue[]">
+  A list of property values and their associated costs.
+</ResponseField>
+
+<ResponseField name="total_cost" type="number">
+  The total cost across all property values.
+</ResponseField>
+
+```json
+{
+  "property_name": "session_id",
+  "values": [
+    {
+      "value": "session_21",
+      "cost": 1.23
+    },
+    {
+      "value": "session_5",
+      "cost": 4.56
+    },
+    {
+      "value": "No_Value",
+      "cost": 0.78
+    }
+  ],
+  "total_cost": 6.57
+}
+```
+
+The API can return special values:
+- `"No_Association"` as property_name if no spans have the requested association properties
+- `"No_Value"` as a value for spans that don't have a value for the specified property
+- `"Unknown_Value"` for spans where the property exists but has an empty value 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds documentation for the `GET /v2/costs/by-association-property` API, detailing request parameters, response structure, and special cases.
> 
>   - **New Documentation**:
>     - Adds `property_costs.mdx` to document the `GET /v2/costs/by-association-property` API.
>   - **Request Parameters**:
>     - `property_name`, `start_time`, `end_time` are required.
>     - `env` and `selected_token_types` are optional.
>     - `selected_token_types` supports filtering by specific token types, excluding `total_tokens`.
>   - **Response Structure**:
>     - Includes `property_name`, `values` (list of property values and costs), and `total_cost`.
>     - Special values: `No_Association`, `No_Value`, `Unknown_Value`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=traceloop%2Fdocs&utm_source=github&utm_medium=referral)<sup> for 9243d9eb47fcfc3c8a546503fbf1d4392a4c59c8. You can [customize](https://app.ellipsis.dev/traceloop/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->