### PR TITLE
add retention_hours to create organization API

### DIFF
--- a/openapi.json
+++ b/openapi.json
@@ -3128,6 +3128,12 @@
           },
           "org_name": {
             "type": "string"
+          },
+          "retention_hours": {
+            "type": "integer",
+            "description": "Data retention period in hours (1-720). Defaults to 720 (1 month).",
+            "minimum": 1,
+            "maximum": 720
           }
         },
         "required": [

--- a/openapi.json
+++ b/openapi.json
@@ -3133,7 +3133,8 @@
             "type": "integer",
             "description": "Data retention period in hours (1-720). Defaults to 720 (1 month).",
             "minimum": 1,
-            "maximum": 720
+            "maximum": 720,
+            "default": 720
           }
         },
         "required": [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable data retention for organizations: when creating an organization you can optionally set a retention period in hours (1–720). If not set, it defaults to 720 hours (approx. 1 month). This expands organization creation to allow per-org retention control for stored data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->