### PR TITLE
Add Oodle as a supported integration for OpenLLMetry

### DIFF
--- a/mint.json
+++ b/mint.json
@@ -135,6 +135,7 @@
         "openllmetry/integrations/langsmith",
         "openllmetry/integrations/middleware",
         "openllmetry/integrations/newrelic",
+        "openllmetry/integrations/oodle",
         "openllmetry/integrations/otel-collector",
         "openllmetry/integrations/oraclecloud",
         "openllmetry/integrations/scorecard",

--- a/openllmetry/integrations/oodle.mdx
+++ b/openllmetry/integrations/oodle.mdx
@@ -1,0 +1,53 @@
+---
+title: "LLM Observability with Oodle and OpenLLMetry"
+sidebarTitle: "Oodle"
+---
+
+[Oodle](https://oodle.ai) is an AI-native observability platform that supports OpenTelemetry for ingesting traces, metrics, and logs.
+
+To get started, sign in to your Oodle account and navigate to **Settings > OpenTelemetry** to obtain your instance ID and API key.
+
+## Using an OpenTelemetry Collector
+
+Deploy an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) and add Oodle as an exporter in your collector configuration:
+
+```yaml
+receivers:
+  otlp:
+    protocols:
+      http:
+
+processors:
+  batch:
+
+exporters:
+  otlphttp/oodle:
+    endpoint: "https://<OODLE_INSTANCE>-otlp.collector.oodle.ai"
+    headers:
+      X-OODLE-INSTANCE: "<OODLE_INSTANCE>"
+      X-API-KEY: "<YOUR_API_KEY>"
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [otlphttp/oodle]
+```
+
+Replace `<OODLE_INSTANCE>` with your Oodle instance ID and `<YOUR_API_KEY>` with the API key from your Oodle dashboard.
+
+Since the `-otlp` endpoint uses standard OTLP paths, you can also point the Traceloop SDK directly to Oodle without a collector:
+
+```bash
+TRACELOOP_BASE_URL=https://<OODLE_INSTANCE>-otlp.collector.oodle.ai
+TRACELOOP_HEADERS="X-OODLE-INSTANCE=<OODLE_INSTANCE>,X-API-KEY=<YOUR_API_KEY>"
+```
+
+Alternatively, point the SDK to a local collector:
+
+```bash
+TRACELOOP_BASE_URL=http://<opentelemetry-collector-hostname>:4318
+```
+
+For more information, check out the [Oodle OpenTelemetry docs](https://docs.oodle.ai/integrations/traces/otel).


### PR DESCRIPTION
* Add Oodle as a supported integration for OpenLLMetry

Add Oodle (https://oodle.ai) integration documentation page and register it in the sidebar navigation. Oodle is an AI-native observability platform that supports OpenTelemetry (OTLP) for ingesting traces, metrics, and logs.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation page for Oodle integration, including setup instructions and configuration examples.
  * Updated navigation to include the new documentation entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->